### PR TITLE
Adding new pruning script with faster run times

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
   * `md5sum`
   * `Perl` packages: `Getopt::Long`, `Graph::Easy`, `Math::BigFloat`, and `IO::Zlib`
   * `R` packages: `optparse`, `tools`, `ggplot2`, `reshape2`, `plyr`, `gtools`, and `LDheatmap`
+  * `python3` packages: `graph-tool`, and `pandas`
 
 To install the entire package just download the source code:
 
@@ -78,7 +79,9 @@ If both `--max_kb_dist` and `--max_snp_dist` are set to `0`, `ngsLD` will output
 
 ### Possible analyses
 ##### LD pruning
-For some analyses, linked sites are typically pruned since their presence can bias results. You can use the script `scripts/prune_graph.pl` to prune your dataset and get a list of unlinked sites.
+For some analyses, linked sites are typically pruned since their presence can bias results. You can use the script `scripts/prune_graph.pl` or `scripts/prune_ngsLD.py` to prune your dataset and get a list of unlinked sites.
+
+###### `scripts/prune_graph.pl`
 
     % perl scripts/prune_graph.pl --in_file testLD_2.ld --max_kb_dist 5 --min_weight 0.5 --out testLD_unlinked.id
 
@@ -88,6 +91,26 @@ For some analyses, linked sites are typically pruned since their presence can bi
 * `--out FILE`: Path to output file [STDOUT]
 
 For more advanced options, please check script help (`perl scripts/prune_graph.pl --help`).
+
+###### `scripts/prune_ngsLD.py`
+
+```
+prune_ngsLD.py --input testLD.ld --max_dist 50000 --min_weight 0.1 --out testLD_unlinked.pos
+```
+
+Required options:
+* `--input FILE`: The .ld output file from ngsLD to be pruned. Can also be gzipped. [STDIN]
+* `--output FILE`: The file to output pruned SNPs to. [STDOUT]
+* `--max_dist`: Maximum distance in bp between nodes to assume they are connected.
+* `--min_weight`: Minimum weight of an edge to assume nodes are connected.
+  
+Additional options:
+* `--field_dist`: Field from input with distances. [3]
+* `--field_weight`: Field from input with weights. [7]
+* `--weight_type`: How to calculate most connected node: sum of (a)bsolute edges' weight [default], sum of (e)dges' weight, or (n)umber of connections.
+* `--keep_heavy`: Keep 'heaviest' nodes, instead of removing them (default)
+* `--print_excl`: File to dump excluded nodes.
+* `--subset`: File with node IDs to include (one per line).
 
 #### LD decay
 If you are interested on the rate of LD decay, you can fit a distribution to your data using the script `scripts/fit_LDdecay.R` to fit LD decay models for ![r^2](http://latex.codecogs.com/png.latex?r^2) ([Hill and Weir, 1988](https://www.ncbi.nlm.nih.gov/pubmed/3376052) and [Remington et al., 2001](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC58755/)) and ![D'](http://latex.codecogs.com/png.latex?D') ([Abecassis et al., 2001](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1234912/)) over physical (or genetic) distance.

--- a/scripts/prune_ngsLD.py
+++ b/scripts/prune_ngsLD.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 #
-# Maintained by Zachary J. Nolen
+# prune_ngsLD.py - Prunes SNPs from ngsLD output to produce a list of 
+# sites in linkage equilibrium.
 #
-# Copyright Zachary J. Nolen
+# Zachary J. Nolen
 #
 # This script aims to prune SNPs from pairwise linkage disequilibrium 
 # estimates output by ngsLD. Not multithreaded, so only assign 
@@ -12,6 +13,8 @@
 # comparisons, so it may be best to break up input into linkage groups, 
 # prune per group, and merge afterwards. Assumes input first two fields 
 # of input are the two positions under comparison in each line.
+
+# Requires: python > 3, graph-tool, pandas
 
 ####### Housekeeping #######
 

--- a/scripts/prune_ngsLD.py
+++ b/scripts/prune_ngsLD.py
@@ -99,11 +99,9 @@ else:
 # get rid of unused properties (other weight measures) from graph
 del G.ep["na"]
 
-# scale weights by preferred weight method from arguments
+# use absolute weight if requested
 if args.weight_type == "a":
 	map_property_values(G.ep["weight"], G.ep["weight"], lambda x: abs(x))
-elif args.weight_type == "n":
-	map_property_values(G.ep["weight"], G.ep["weight"], lambda x: 1)
 
 # create properties needed to filter out edges where dist > threshold and
 # weight < threshold
@@ -124,6 +122,10 @@ if args.min_weight:
 	G.set_edge_filter(drop_weight, inverted=True)
 	G.purge_edges()
 	G.clear_filters()
+
+# convert filtered weights to number of edges if requested
+if args.weight_type == "n":
+	map_property_values(G.ep["weight"], G.ep["weight"], lambda x: 1)
 
 ####### Prune graph #######
 

--- a/scripts/prune_ngsLD.py
+++ b/scripts/prune_ngsLD.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+#
+# Maintained by Zachary J. Nolen
+#
+# Copyright Zachary J. Nolen
+#
+# This script aims to prune SNPs from pairwise linkage disequilibrium 
+# estimates output by ngsLD. Not multithreaded, so only assign 
+# multiple cores if required to increase memory allowance on your 
+# cluster. Memory usage seems to require RAM equivalent to ~60-90% of 
+# uncompressed input file size. Runtime depends on number of pairwise 
+# comparisons, so it may be best to break up input into linkage groups, 
+# prune per group, and merge afterwards.
+
+####### Housekeeping #######
+
+# import modules needed to show help info
+import argparse
+import sys
+
+# parse input arguments
+parser = argparse.ArgumentParser(description='Prunes SNPs from ngsLD output to produce a list of sites in linkage equilibrium.')
+
+parser.add_argument("--input",
+					help="The .ld output file from ngsLD to be pruned. Can also be gzipped.",
+					default=sys.stdin)
+parser.add_argument("--output",
+					help="The file to output pruned SNPs to.",
+					default=sys.stdout)
+parser.add_argument("--max_dist", help="Maximum distance in bp between nodes to assume they are connected.")
+parser.add_argument("--min_weight", help="Minimum weight of an edge to assume nodes are connected.")
+parser.add_argument("--weight_type", help="How to calculate most connected node: sum of (a)bsolute edges' weight [default], sum of (e)dges' weight, or (n)umber of connections.", default="a")
+parser.add_argument("--keep_heavy", help="Keep 'heaviest' nodes, instead of removing them (default)", action='store_true')
+args = parser.parse_args()
+
+# import remaining necessary modules
+import datetime
+import csv
+import pandas as pd
+from graph_tool.all import *
+import gzip
+
+# log start time
+begin_time = datetime.datetime.now()
+
+####### Read in data #######
+
+# check if input is compressed or plain text
+print("Checking if file is gzipped...", file=sys.stderr)
+def is_gz_file(filepath):
+    with open(filepath, 'rb') as test_f:
+        return test_f.read(2) == b'\x1f\x8b'
+
+# read input into graph object, whether compressed or not
+if is_gz_file(args.input):
+	with gzip.open(args.input, mode="rt") as f:
+		print("Reading in data...", file=sys.stderr)
+		G = load_graph_from_csv(f, directed = False, 
+			eprop_types = ["int32_t","bool","bool","bool","double"],
+			eprop_names = ["dist","na","na","na","r2"], hashed = True, 
+			csv_options = {'delimiter': '\t'})
+else:
+	print("Reading in data...", file=sys.stderr)
+	G = load_graph_from_csv(args.input, directed = False, 
+		eprop_types = ["int32_t","bool","bool","bool","double"],
+		eprop_names = ["dist","na","na","na","r2"], hashed = True, 
+		csv_options = {'delimiter': '\t'})
+
+####### Filter graph #######
+
+# get rid of unused properties (other weight measures) from graph
+del G.ep["na"]
+
+# scale weights by preferred weight method from arguments
+if args.weight_type == "a":
+	map_property_values(G.ep["r2"], G.ep["r2"], lambda x: abs(x))
+elif args.weight_type == "n":
+	map_property_values(G.ep["r2"], G.ep["r2"], lambda x: 1)
+
+# create properties needed to filter out edges where dist > threshold and
+# weight < threshold
+drop_dist = G.new_edge_property("bool")
+drop_r2 = G.new_edge_property("bool")
+weight = G.new_vertex_property("double")
+
+# determine which edges to filter by dist and weight based on input arguments
+if args.max_dist:
+	print("Filtering edges by distance...", file=sys.stderr)
+	map_property_values(G.ep["dist"], drop_dist, lambda x: x > int(args.max_dist))
+	G.set_edge_filter(drop_dist, inverted=True)
+	G.purge_edges()
+	G.clear_filters()
+if args.min_weight:
+	print("Filtering edges by weight...", file=sys.stderr)
+	map_property_values(G.ep["r2"], drop_r2, lambda x: x < float(args.min_weight))
+	G.set_edge_filter(drop_r2, inverted=True)
+	G.purge_edges()
+	G.clear_filters()
+
+####### Prune graph #######
+
+# print out messages at start of pruning describing starting point and method
+if args.keep_heavy:
+	print("Beginning pruning by dropping neighbors of heaviest position...", 
+			file=sys.stderr)
+else:
+	print("Beginning pruning by dropping heaviest position...",
+		file=sys.stderr)
+print("Starting with "+str(G.num_vertices())+" positions with "+
+	str(G.num_edges())+" edges between them...", file=sys.stderr)
+
+# prune while edges > 0; uncomment print lines for some debugging
+while True:
+	nodes = G.num_vertices()
+	edges = G.num_edges()
+	if edges == 0:
+		break
+	if (nodes % 1000 == 0) and nodes > 0:
+		print(str(nodes)+" positions remaining with "+str(edges)+
+			" edges between them...", file=sys.stderr)
+	#print("Nodes remaining = "+str(nodes), file=sys.stderr)
+	#print("Edges remaining = "+str(edges), file=sys.stderr)
+	incident_edges_op(G, "out", "sum", G.ep["r2"], weight)
+	max_weight = max(weight)
+	#print("Heaviest node weight = "+str(max_weight), file=sys.stderr)
+	heavy = find_vertex(G, weight, max_weight)
+	if args.keep_heavy:
+		#print("Dropping heavy neighbors...", file=sys.stderr)
+		heavy_neighbors = G.get_out_neighbors(heavy[0])
+		G.remove_vertex(heavy_neighbors, fast = True)
+	else:
+		#print("Dropping heavy...", file=sys.stderr)
+		G.remove_vertex(heavy[0], fast = True)
+
+####### Output creation #######
+
+print("Pruning complete! Pruned graph contains "+str(nodes)+" positions.",
+	file=sys.stderr)
+print("Exporting kept positions to file...", file=sys.stderr)
+pruned_df = pd.DataFrame([G.vp["name"][v] for v in G.get_vertices()])
+pruned_df = pruned_df[0].str.split(pat=":", expand = True)
+pruned_df.columns = ['chr','pos']
+pruned_df.chr = pruned_df.chr.astype('string')
+pruned_df.pos = pruned_df.pos.astype('int')
+pruned_df = pruned_df.sort_values('pos')
+pruned_df.to_csv(args.output, sep="_", quoting=csv.QUOTE_NONE, 
+	header = False, index = False)
+
+print("Total runtime: "+str(datetime.datetime.now() - begin_time),
+	file=sys.stderr)

--- a/scripts/prune_ngsLD.py
+++ b/scripts/prune_ngsLD.py
@@ -35,6 +35,7 @@ parser.add_argument("--min_weight", help="Minimum weight of an edge to assume no
 parser.add_argument("--weight_type", help="How to calculate most connected node: sum of (a)bsolute edges' weight [default], sum of (e)dges' weight, or (n)umber of connections.", default="a")
 parser.add_argument("--keep_heavy", help="Keep 'heaviest' nodes, instead of removing them (default)", action='store_true')
 parser.add_argument("--print_excl", help="File to dump excluded nodes.")
+parser.add_argument("--subset", help="File with node IDs to include (one per line).")
 args = parser.parse_args()
 
 # import remaining necessary modules
@@ -122,6 +123,14 @@ if args.min_weight:
 	G.clear_filters()
 
 ####### Prune graph #######
+
+# subset sites if requested
+if args.subset:
+	with open(args.subset) as f:
+		subset_nodes = f.read().splitlines()
+	for i in G.get_vertices():
+		if G.vp["name"][i] not in subset_nodes:
+			G.remove_vertex(find_vertex(G, G.vp["name"], G.vp["name"][i]), fast = True)
 
 # print out messages at start of pruning describing starting point and method
 if args.keep_heavy:

--- a/scripts/prune_ngsLD.py
+++ b/scripts/prune_ngsLD.py
@@ -177,13 +177,13 @@ while True:
 		print("Max weight node and weight: "+str(G.vp["name"][heavy])+" "+str(max_weight), file=sys.stderr)
 	if args.keep_heavy:
 		heavy_neighbors = G.get_out_neighbors(heavy)
-		G.remove_vertex(heavy_neighbors, fast = True)
 		if args.print_excl:
 			dropped=dropped+[G.vp["name"][i] for i in heavy_neighbors]
+		G.remove_vertex(heavy_neighbors, fast = True)
 	else:
-		G.remove_vertex(heavy, fast = True)
 		if args.print_excl:
 			dropped=dropped+[G.vp["name"][heavy]]
+		G.remove_vertex(heavy, fast = True)
 
 ####### Output creation #######
 

--- a/scripts/prune_ngsLD.py
+++ b/scripts/prune_ngsLD.py
@@ -196,7 +196,7 @@ pruned_df.columns = ['chr','pos']
 pruned_df.chr = pruned_df.chr.astype('string')
 pruned_df.pos = pruned_df.pos.astype('int')
 pruned_df = pruned_df.sort_values(['chr','pos'])
-pruned_df.to_csv(args.output, sep="_", quoting=csv.QUOTE_NONE, 
+pruned_df.to_csv(args.output, sep=":", quoting=csv.QUOTE_NONE, 
 	header = False, index = False)
 
 if args.print_excl:
@@ -207,7 +207,7 @@ if args.print_excl:
 	dropped_df.chr = dropped_df.chr.astype('string')
 	dropped_df.pos = dropped_df.pos.astype('int')
 	dropped_df = dropped_df.sort_values(['chr','pos'])
-	dropped_df.to_csv(args.print_excl, sep="_", quoting=csv.QUOTE_NONE, 
+	dropped_df.to_csv(args.print_excl, sep=":", quoting=csv.QUOTE_NONE, 
 		header = False, index = False)
 
 print("Total runtime: "+str(datetime.datetime.now() - begin_time),


### PR DESCRIPTION
Hey @fgvieira! I have finished the rewrite of your pruning method into graph-tool for python as we talked about in #25, and I think will be helpful for some with run time issues. I've tested it on one of my smaller datasets of ~60000 nodes and it runs in a little under an hour, compared to the perl script which took 6 hours. I've also found that this run time difference can increase with the number of nodes. Overall, it seems to result in the same outcome, with the pruning returning the same sites:

```
prune_ngsLD.py.log

Starting with 63706 positions with 2597428 edges between them...
Pruning complete! Pruned graph contains 4042 positions.
```

```
prune_graph.pl.log

### Pruning graph (2597428 edges between 63706 nodes)
### Run finished (final graph with 4042 nodes)
```

Both used similar amounts of RAM, which unfortunately is still a bit high (usually approaching the size of the uncompressed ngsLD output), so I still tend to make beagle files in chunks, prune them, then merge them. This is also good for run time, as even if it can be faster at more nodes, it still can take quite a long time.

I also tried to include most of the options found in your script in this one. I've tested them all, but not thoroughly, and some I'm sure could be coded better, but they at least seem to work. As far as the defaults go, I've been using them in a pipeline I'm working on for awhile now with no problems.

Let me know what your thoughts on this are and if you have any suggestions or tests you'd like done!